### PR TITLE
Allow application to specify custom method to show the confirm modal

### DIFF
--- a/src/lib/ConfirmationController.js
+++ b/src/lib/ConfirmationController.js
@@ -6,6 +6,7 @@ export default class ConfirmationController {
     acceptSelector: '#confirm-accept',
     denySelector: '.confirm-cancel',
     animationDuration: 300,
+    showConfirmCallback: null,
     contentSlots: {
       title: {
         contentAttribute: 'turbo-confirm',
@@ -64,6 +65,10 @@ export default class ConfirmationController {
   #showConfirm(element) {
     this.#fillSlots(element)
     this.dialogTarget.classList.add(this.#config.activeClass)
+    if (this.#config.showConfirmCallback) {
+      this.#config.showConfirmCallback(this.dialogTarget)
+    }
+
     this.#setupListeners()
   }
 


### PR DESCRIPTION
We use shoelace dialogs to hold our confirm modals.... they aren't made visible by attaching a class; they need an event or JS trigger. Allow the application itself to configure a callback to show the modal.