### PR TITLE
Adapt the ConfirmController to integrate more cleanly with stimulus-bound buttons

### DIFF
--- a/src/lib/ConfirmationController.js
+++ b/src/lib/ConfirmationController.js
@@ -1,3 +1,5 @@
+import { dispatch } from './utils.js'
+
 export default class ConfirmationController {
   #originalSubmitter
   #initialContent
@@ -47,12 +49,22 @@ export default class ConfirmationController {
   }
 
   accept() {
-    // re-trigger the original action
-    this.#originalSubmitter.click()
+    const submitter = this.#originalSubmitter
+    this.#teardown()
+
+    if (submitter.getAttribute('data-confirm-click') === 'false') {
+      dispatch('confirm-accept', submitter, {})
+    } else {
+      // re-trigger the original action
+      submitter.click()
+    }
   }
 
   deny() {
+    const submitter = this.#originalSubmitter
     this.#teardown()
+
+    dispatch('confirm-deny', submitter, {})
   }
 
   get dialogTarget() {

--- a/test/ConfirmationController.test.js
+++ b/test/ConfirmationController.test.js
@@ -75,6 +75,40 @@ describe('ConfirmationController', () => {
 
       expect(testState.success).toBe(true)
     })
+
+    it('clicking accept tears down the dialog', () => {
+      const dialog = document.getElementById('confirm')
+      const acceptButton = document.getElementById('confirm-accept')
+
+      const controller = new ConfirmationController()
+      controller.perform(event)
+
+      expect(dialog.classList.contains('modal--active')).toBe(true)
+
+      acceptButton.click()
+
+      expect(dialog.classList.contains('modal--active')).toBe(false)
+    })
+
+    it('clicking accepts dispatches a custom event if the original submitter opted out of reclick behavior', () => {
+      const testState = { success: false }
+      const acceptButton = document.getElementById('confirm-accept')
+      const originalSubmitter = document.getElementById('trigger')
+      originalSubmitter.setAttribute('data-confirm-click', 'false')
+      originalSubmitter.onclick = () => { testState.success = 'click' }
+      originalSubmitter.addEventListener('rms:confirm-accept', () => {
+        testState.success = 'custom'
+      })
+
+      const controller = new ConfirmationController()
+      controller.perform(event)
+
+      expect(testState.success).toBe(false)
+
+      acceptButton.click()
+
+      expect(testState.success).toBe('custom')
+    })
   })
 
   describe('denying the confirmation', () => {
@@ -91,5 +125,26 @@ describe('ConfirmationController', () => {
       expect(dialog.classList.contains('modal--active')).toBe(false)
     })
 
+    it('dispatches a custom event on the submitter', () => {
+      const testState = { success: false }
+
+      const controller = new ConfirmationController()
+
+      const cancelButton = document.getElementById('cancel-button')
+
+      const dialog = document.getElementById('confirm')
+      controller.perform(event)
+
+      const originalSubmitter = document.getElementById('trigger')
+      originalSubmitter.onclick = () => { testState.success = 'click' }
+
+      originalSubmitter.addEventListener('rms:confirm-deny', () => {
+        testState.success = 'denied'
+      })
+
+      cancelButton.click()
+
+      expect(testState.success).toBe('denied')
+    })
   })
 })


### PR DESCRIPTION
- when accepting the confirm modal, tear down the modal just-in-case the action confirmed does not involve a full page load
- when denying the confirm modal, trigger a `rms:confirm-deny` event on the submitter button
- when accepting the confirm modal, if the submitter button declares data-confirm-click='false', then dispatch a `rms:confirm-accept` event on the submitter button instead of reclicking