### PR TITLE
Resolve potential Webpack compile issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rolemodel/turbo-confirm",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Drop-in upgrade for Rails' data-turbo-confirm feature to support custom HTML dialogs.",
   "main": "src/index.js",
   "directories": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { dispatch, TurboConfirmError } from './lib/utils.js'
-import { TurboConfirm } from './lib/TurboConfirm'
+import { TurboConfirm } from './lib/TurboConfirm.js'
 
 const start = (options) => {
   const tc = new TurboConfirm(options)

--- a/src/lib/TurboConfirm.js
+++ b/src/lib/TurboConfirm.js
@@ -1,4 +1,4 @@
-import ConfirmationController from './ConfirmationController'
+import ConfirmationController from './ConfirmationController.js'
 
 export class TurboConfirm {
   #controller


### PR DESCRIPTION
In the 2.0.0 release, I sloppily left off `.js` extensions from 2 relative import paths.  This causes issues with certain JavaScript bundling configurations.

This PR resolves those issues by adding file extensions to all relative import paths within the package.