### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RoleModel/turbo-confirm/security/code-scanning/4](https://github.com/RoleModel/turbo-confirm/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves publishing packages, it requires `contents: read` for basic repository access and `packages: write` for publishing to npm and GitHub Package Registry. These permissions will be added at the workflow level to apply to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
