### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+permissions:
+  contents: read
 jobs:
   test:
     timeout-minutes: 5


### PR DESCRIPTION
Potential fix for [https://github.com/RoleModel/turbo-confirm/security/code-scanning/3](https://github.com/RoleModel/turbo-confirm/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs `contents: read` to check out the repository and install dependencies. No write permissions are necessary for this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
