### PR TITLE
Fix race condition when restoring initial content

### DIFF
--- a/src/lib/ConfirmationController.js
+++ b/src/lib/ConfirmationController.js
@@ -3,6 +3,7 @@ import { TurboConfirmError } from './utils.js'
 export default class ConfirmationController {
   initialContent
   #resolve
+  #restoreTimeoutId
 
   constructor(delegate) {
     this.delegate = delegate
@@ -12,6 +13,7 @@ export default class ConfirmationController {
   }
 
   showConfirm(contentMap) {
+    clearTimeout(this.#restoreTimeoutId)
     this.#storeInitialContent()
 
     for(const [selector, content] of Object.entries(contentMap)) {
@@ -52,7 +54,7 @@ export default class ConfirmationController {
     this.delegate.hideConfirm(this.element)
     this.#teardownListeners()
 
-    setTimeout(this.#restoreInitialContent.bind(this), this.delegate.animationDuration)
+    this.#restoreTimeoutId = setTimeout(this.#restoreInitialContent.bind(this), this.delegate.animationDuration)
   }
 
   #setupListeners() {
@@ -68,6 +70,8 @@ export default class ConfirmationController {
   }
 
   #storeInitialContent() {
+    if (this.initialContent !== undefined) return
+
     try {
       this.initialContent = this.element.innerHTML
     } catch (error) {
@@ -85,5 +89,7 @@ export default class ConfirmationController {
        * error message will be thrown on the next go round (during #storeInitialContent).
        */
     }
+
+    this.initialContent = undefined
   }
 }

--- a/test/system/direct.spec.js
+++ b/test/system/direct.spec.js
@@ -277,4 +277,78 @@ test.describe('direct invocation', () => {
       await expect(header).toContainText('Custom Confirm With Content')
     })
   })
+
+  test('re-triggering after being dismissed shows the new content', async ({ page }) => {
+    await page.goto('/confirms/div')
+    await page.clock.install()
+    await page.clock.pauseAt(new Date())
+
+    const dialog = page.getByTestId('confirm')
+    const dialogTitle = page.locator('#confirm-title')
+    const defaultContent = await dialog.textContent() || ''
+    const animationDuration = 300
+
+    page.evaluate(`
+      window.tc = new TurboConfirm({ animationDuration: ${animationDuration} })
+      window.tc.confirm('First Message')
+    `)
+
+    await expect(dialog).toBeVisible()
+    await expect(dialogTitle).toContainText('First Message')
+
+    await dialog.getByText('Cancel').click()
+
+    await expect(dialog).toBeHidden()
+
+    page.evaluate(`window.tc.confirm('Second Message')`)
+
+    await expect(dialog).toBeVisible()
+    await expect(dialogTitle).toContainText('Second Message')
+
+    // let the first confirm's pending content-restore timer fire while the
+    // re-triggered confirm is showing
+    await page.clock.runFor(animationDuration)
+
+    await expect(dialog).toBeVisible()
+    await expect(dialogTitle).toContainText('Second Message')
+    await expect(dialog).not.toContainText(defaultContent)
+
+    await dialog.getByText('Cancel').click()
+
+    await expect(dialog).toBeHidden()
+  })
+
+  test('dismissing after being re-triggered reverts to the original initial content', async ({ page }) => {
+    await page.goto('/confirms/div')
+    await page.clock.install()
+    await page.clock.pauseAt(new Date())
+
+    const dialog = page.getByTestId('confirm')
+    const defaultContent = await dialog.textContent() || ''
+    const animationDuration = 300
+
+    page.evaluate(`
+      window.tc = new TurboConfirm({ animationDuration: ${animationDuration} })
+      window.tc.confirm('First Message')
+    `)
+
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByText('Cancel').click()
+
+    await expect(dialog).toBeHidden()
+
+    page.evaluate(`window.tc.confirm('Second Message')`)
+
+    await expect(dialog).toBeVisible()
+    await page.clock.runFor(animationDuration)
+
+    await dialog.getByText('Cancel').click()
+
+    await expect(dialog).toBeHidden()
+
+    await page.clock.runFor(animationDuration)
+
+    await expect(dialog).toContainText(defaultContent)
+  })
 })

--- a/test/system/direct.spec.js
+++ b/test/system/direct.spec.js
@@ -2,7 +2,7 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('direct invocation', () => {
-  test ('with a message', async ({ page }) => {
+  test('with a message', async ({ page }) => {
     await page.goto('/confirms/div')
 
     const header = page.getByTestId('header')
@@ -53,7 +53,7 @@ test.describe('direct invocation', () => {
     await expect(header).toContainText('Direct Confirm Accepted')
   })
 
-  test ('without a message', async ({ page }) => {
+  test('without a message', async ({ page }) => {
     await page.goto('/confirms/dialog')
 
     const header = page.getByTestId('header')
@@ -101,7 +101,7 @@ test.describe('direct invocation', () => {
     await expect(header).toContainText('Accepted No Message')
   })
 
-  test ('with content', async ({ page }) => {
+  test('with content', async ({ page }) => {
     await page.goto('/confirms/div')
 
     const header = page.getByTestId('header')
@@ -166,7 +166,7 @@ test.describe('direct invocation', () => {
   })
 
   test.describe('using custom config', () => {
-    test ('with or without a message', async ({ page }) => {
+    test('with or without a message', async ({ page }) => {
       await page.goto('/confirms/custom')
 
       const header = page.getByTestId('header')
@@ -236,7 +236,7 @@ test.describe('direct invocation', () => {
       await expect(header).toContainText('Custom Confirm Accepted')
     })
 
-    test ('with content', async ({ page }) => {
+    test('with content', async ({ page }) => {
       await page.goto('/confirms/custom')
 
       const header = page.getByTestId('header')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please take the time to explain why these changes are necessary and then list them in detail -->

## Why?

If a confirm is triggered a second time before the `#restoreInitialContent` timeout fires, the newly-opened confirm will be cleared. In this scenario, the confirm's initial content would also become corrupted, since it would hold the first confirm's content instead of the real initial content. While this case is unlikely to happen in real production usage, it can easily occur in end-to-end tests.

## What Changed

* [x] Clear the content restore timeout in `showConfirm`
* [x] Guard `#storeInitialContent` against overwriting the real initial content
* [x] Added tests for both scenarios
* [x] Removed extra whitespace in function calls between the function and the parentheses in `test/system/direct.spec.js`, making it match the style used in the other test files.
